### PR TITLE
Docker Compose starts Doichain core and Doichain dApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This repository provides the necessary Docker Commpose file, Dockerfiles and/or 
 - Doichain Core Node
 - Doichain dApp (for Email Marketing)
 - MongoDB (dependency for Doichain dApp)
-- P2Pool (P2P Merge Mining Pool to merge mine Bitcoin and Doichain)
-- ElectrumX Server
+- (planed) P2Pool (P2P Merge Mining Pool to merge mine Bitcoin and Doichain)
+- (planed) ElectrumX Server
+- (planed) Mailu Server
 
 ## Installation process
 1. Clone this repo ```git clone ````

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ version: '3.7'
 
 services:
   doichain:
-    image: "doichain/node-only:latest" 
+    image: "doichain/node-only:dc0.20.1.11_1" 
     hostname: doichain
     ports:
       - "8339:8339"
     environment:
       - RPC_PASSWORD=password
-      - RPC_ALLOW_IP=::/0
+      - RPC_ALLOW_IP=0.0.0.0/0 #::/0
     #  - REGTEST=true
     #  - CONNECTION_NODE=altbob 
 #    dns_search: ci-doichain.org
@@ -31,6 +31,7 @@ services:
       - MONGO_URL="mongodb://mongo:27017"
       - DAPP_HOST=localhost    
       - DAPP_PORT=3000
+      - RPC_HOST=doichain 
       - RPC_PORT=8339   
       - RPC_USER=admin
       - RPC_PASSWORD=password
@@ -38,7 +39,7 @@ services:
       - DAPP_SMTP_HOST=smtp
       - DAPP_SMTP_PASS=doichain
       - DAPP_SMTP_PORT=587
-      - DAPP_SMTP_DEFAULT_FROM=DAPP_SMTP_DEFAULT_FROM=validator@doichain.org
+      - DAPP_SMTP_DEFAULT_FROM=validator@doichain.org
     # stdin_open: true
     # tty: true
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: "doichain/node-only:latest" 
     hostname: doichain
     ports:
-      - "18543:18332"
+      - "8339:8339"
     environment:
       - RPC_PASSWORD=password
       - RPC_ALLOW_IP=::/0
@@ -28,11 +28,19 @@ services:
       - "3000:3000"
     environment:
       - DOICHAIN_DAPP_VER=v0.0.9.114
+      - MONGO_URL="mongodb://mongo:27017"
       - DAPP_HOST=localhost    
-      - DAPP_PORT=3000   
-      
-    #stdin_open: true
-    #tty: true
+      - DAPP_PORT=3000
+      - RPC_PORT=8339   
+      - RPC_USER=admin
+      - RPC_PASSWORD=password
+      - DAPP_SMTP_USER=doichain
+      - DAPP_SMTP_HOST=smtp
+      - DAPP_SMTP_PASS=doichain
+      - DAPP_SMTP_PORT=587
+      - DAPP_SMTP_DEFAULT_FROM=DAPP_SMTP_DEFAULT_FROM=validator@doichain.org
+    # stdin_open: true
+    # tty: true
     networks:
       static-network:
         ipv4_address: 172.20.0.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,17 @@ services:
     networks:
       static-network:
         ipv4_address: 172.20.0.7
+
+  regtest-mongo:
+      image: "mongo:3.2"
+      hostname: mongo
+      expose:
+        - "27017"
+      ports:
+        - "28017:27017"
+      networks:
+        static-network:
+          ipv4_address: 172.20.0.8
   
 networks:
   static-network:

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
-# FROM node:12
-FROM ubuntu:20.04 AS buck
+FROM node:14
+#FROM ubuntu:20.04 AS buck
 
 ARG DOICHAIN_VER=master
 ARG DOICHAIN_DAPP_VER=master
@@ -22,6 +22,7 @@ ENV DAPP_SMTP_USER "doichain"
 ENV DAPP_SMTP_HOST "smtp"
 ENV DAPP_SMTP_PASS ""
 ENV DAPP_SMTP_PORT 587
+ENV DAPP_SMTP_DEFAULT_FROM "validator@doichain.org"
 ENV CONNECTION_NODE 5.9.154.226
 ENV NODE_PORT 8338
 ENV NODE_PORT_TESTNET 18338
@@ -40,7 +41,7 @@ RUN adduser --disabled-password --gecos '' doichain && \
 	adduser doichain sudo && \
 	echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \ 
   apt update -qq && apt install -qq -y --no-install-recommends \
-  bash git curl ca-certificates \ 
+  bash git curl jq ca-certificates \ 
   && (curl https://install.meteor.com/  | sh) \
   && cd /home/doichain  \ 
   && git clone --branch ${DOICHAIN_DAPP_VER} https://github.com/Doichain/dapp.git && chown -R doichain dapp && cd dapp
@@ -60,8 +61,8 @@ COPY entrypoint.sh entrypoint.sh
 COPY start.sh start.sh
 
 WORKDIR /home/doichain/dapp/
-RUN meteor npm install --save bcrypt && meteor build build/ --architecture os.linux.x86_64 --directory --server ${DAPP_HOST}:${DAPP_PORT}  
-
+RUN  meteor npm install  && meteor npm install --save bcrypt @babel/runtime && meteor build build/ --architecture os.linux.x86_64 --directory --server ${DAPP_HOST}:${DAPP_PORT} && \  
+    cd /home/doichain/dapp/build/bundle/programs/server && npm install && npm install @babel/runtime 
 WORKDIR /home/doichain
 ENTRYPOINT ["scripts/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ if [ ! -f "$DAPP_SETTINGS_FILE" ]; then
 		      "smtps":false,
 		      "port": "'$DAPP_SMTP_PORT'",
 		      "NODE_TLS_REJECT_UNAUTHORIZED":"0",
-		      "defaultFrom": "doichain@example-domain.org"
+		      "defaultFrom": "'$DAPP_SMTP_DEFAULT_FROM'"
 	    }
 	  }'
 	  if [ $DAPP_VERIFY = true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ if [ ! -f "$DAPP_SETTINGS_FILE" ]; then
 			"doiMailFetchUrl": "'$DAPP_DOI_URL'",
 			"doichain": {
 		    "host":"'$RPC_HOST'",
-		    "port": "'$_RPC_PORT'",
+		    "port": "'$RPC_PORT'",
 		    "username": "'$RPC_USER'",
 		    "password": "'$RPC_PASSWORD'"
 		  }
@@ -59,7 +59,7 @@ if [ ! -f "$DAPP_SETTINGS_FILE" ]; then
 	  DAPP_SETTINGS=$DAPP_SETTINGS'"confirm": {
 			"doichain": {
 		      "host":"'$RPC_HOST'",
-			  "port": "'$_RPC_PORT'",
+			  "port": "'$RPC_PORT'",
 			  "username": "'$RPC_USER'",
 			  "password": "'$RPC_PASSWORD'",
 			  "address": "'$CONFIRM_ADDRESS'"
@@ -82,7 +82,7 @@ if [ ! -f "$DAPP_SETTINGS_FILE" ]; then
 	  DAPP_SETTINGS=$DAPP_SETTINGS'"verify": {
 			"doichain": {
 		    "host":"'$RPC_HOST'",
-		    "port": "'$_RPC_PORT'",
+		    "port": "'$RPC_PORT'",
 		    "username": "'$RPC_USER'",
 		    "password": "'$RPC_PASSWORD'"
 		  }

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-	#!/bin/bash
+#!/bin/bash
 
 export METEOR_SETTINGS=$(cat /home/doichain/data/dapp/settings.json)
 export PORT=$HTTP_PORT
@@ -6,7 +6,7 @@ export ROOT_URL=http://$DAPP_HOST:$DAPP_PORT
 
 BUILD=false
 _BUILD=$1
-_BUILD="${VARIABLE:-BUILD}"
+_BUILD="${_BUILD:-BUILD}"
 if [ $_BUILD = 'build' ]; then
 	git -C /home/doichain/dapp pull origin master
 	echo "starting creating bundle $DAPP_HOST:$DAPP_PORT" 
@@ -30,4 +30,4 @@ echo "starting dapp via node bundle"
 cd /home/doichain/dapp 
 #node build/bundle/main.js > dapp.log  2>&1 & echo $! > dapp.pid
 node build/bundle/main.js 
-sleep 360
+sleep infinity


### PR DESCRIPTION
# Next Steps
- add volume to doichain service to mount .doichain directory
- add volume to dapp service to mount data (settings) directory
- add volume to mongo service to mount db directories
- add .env file to configure variables in docker-compose file
- add folder for p2pool + Dockerfile + image on docker hub 
- add  electrumx service to docker-compose.yml